### PR TITLE
libsmartctl: add device type as a param to information and vendor att…

### DIFF
--- a/libsmartctl.cpp
+++ b/libsmartctl.cpp
@@ -170,8 +170,7 @@ Client::Client() {
 }
 
 ctlerr_t Client::initDevice(smart_device_auto_ptr &device,
-                            std::string const &devname) {
-  const char *type = 0;
+                            std::string const &devname, const char *type) {
   device = smi()->get_smart_device(devname.c_str(), type);
   if (!device) {
     return GETDEVICERR;
@@ -191,7 +190,7 @@ ctlerr_t Client::initDevice(smart_device_auto_ptr &device,
   return NOERR;
 }
 
-DevInfoResp Client::getDevInfo(std::string const &devname) {
+DevInfoResp Client::getDevInfo(std::string const &devname, const char *type) {
   DevInfoResp resp = {};
 
   ata_print_options ataopts;
@@ -201,7 +200,7 @@ DevInfoResp Client::getDevInfo(std::string const &devname) {
   ataopts.drive_info = scsiopts.drive_info = nvmeopts.drive_info = true;
 
   smart_device_auto_ptr device;
-  resp.err = initDevice(device, devname);
+  resp.err = initDevice(device, devname, type);
   if (resp.err != NOERR) {
     return resp;
   }
@@ -213,7 +212,8 @@ DevInfoResp Client::getDevInfo(std::string const &devname) {
   return resp;
 }
 
-DevVendorAttrsResp Client::getDevVendorAttrs(std::string const &devname) {
+DevVendorAttrsResp Client::getDevVendorAttrs(std::string const &devname,
+                                             const char *type) {
   DevVendorAttrsResp resp = {};
 
   ata_print_options ataopts;
@@ -224,7 +224,7 @@ DevVendorAttrsResp Client::getDevVendorAttrs(std::string const &devname) {
       nvmeopts.smart_vendor_attrib = true;
 
   smart_device_auto_ptr device;
-  resp.err = initDevice(device, devname);
+  resp.err = initDevice(device, devname, type);
   if (resp.err != NOERR) {
     return resp;
   }

--- a/libsmartctl.h
+++ b/libsmartctl.h
@@ -69,23 +69,30 @@ public:
   static Client &getClient();
 
   /**
-   *@brief Retrieves drive information
+   *@brief Retrieves drive information.
    *
-   * @param string of full path device name
+   * @param String of full path device name.
    *
-   * @return map of information type and value, both strings
+   * @param C string of device type, if left blank, auto device type detection
+   * will be used.
+   *
+   * @return Map of information type and value, both strings.
    */
-  DevInfoResp getDevInfo(std::string const &devname);
+  DevInfoResp getDevInfo(std::string const &devname, const char *type = 0);
 
   /**
    *@brief Retrieves drive vendor attributes
    *
    * @param string of full path device name
    *
+   * @param C string of device type, if left blank, auto device type detection
+   * will be used.
+   *
    * @return a vector maps containing string key and values of vendor attribute
    *type name and attribute type values
    */
-  DevVendorAttrsResp getDevVendorAttrs(std::string const &devname);
+  DevVendorAttrsResp getDevVendorAttrs(std::string const &devname,
+                                       const char *type = 0);
 
   Client(Client const &l) = delete;
   void operator=(Client const &l) = delete;
@@ -95,8 +102,8 @@ private:
   // database.  User supplied drive databases are not supported at this.
   Client();
 
-  ctlerr_t initDevice(smart_device_auto_ptr &device,
-                      std::string const &devname);
+  ctlerr_t initDevice(smart_device_auto_ptr &device, std::string const &devname,
+                      const char *type);
 };
 }
 #endif


### PR DESCRIPTION
…ributes api

- Device type is now passed into device initiation from the current exposed API's, getDevInfo and getDevVendorAttrs
