### PR TITLE
libsmartctl: minor changes

### DIFF
--- a/libsmartctl.cpp
+++ b/libsmartctl.cpp
@@ -57,6 +57,20 @@ const char *libsmartctl_cpp_cvsid = "$Id$" CONFIG_H_CVSID LIBSMARTCTL_H_CVSID;
 
 namespace libsmartctl {
 
+const std::string errStr(ctlerr_t err) {
+  static const std::map<ctlerr_t, std::string> errs = {
+      {NOERR, "No errors"},
+      {POWERMODEBELOWOPTION, "The power mode is below the configured option"},
+      {FAILEDDEVICEIDREAD, "Device read failure"},
+      {FAILEDSMARTCMD, "Test SMART command failed"},
+      {GETDEVICERR, "Could not retrieve device information"},
+      {DEVICEOPENERR, "Could not open device"},
+      {UNSUPPORTEDDEVICETYPE, "Device type is not supported"},
+  };
+
+  return errs.at(err);
+}
+
 class Client::Impl {
 
 public:
@@ -104,7 +118,7 @@ private:
 
 public:
   CantIdDevResp cantIdDev(std::string const &devname, std::string const &type) {
-    CantIdDevResp resp = {};
+    CantIdDevResp resp;
 
     smart_device_auto_ptr device;
     ctlerr_t err = initDevice(device, devname, type);
@@ -134,7 +148,7 @@ public:
   }
 
   DevInfoResp getDevInfo(std::string const &devname, std::string const &type) {
-    DevInfoResp resp = {};
+    DevInfoResp resp;
 
     ata_print_options ataopts;
     scsi_print_options scsiopts;
@@ -159,7 +173,7 @@ public:
 
   DevVendorAttrsResp getDevVendorAttrs(std::string const &devname,
                                        std::string const &type) {
-    DevVendorAttrsResp resp = {};
+    DevVendorAttrsResp resp;
 
     ata_print_options ataopts;
     scsi_print_options scsiopts;

--- a/libsmartctl.h
+++ b/libsmartctl.h
@@ -47,16 +47,22 @@ namespace libsmartctl {
 struct DevInfoResp {
   std::map<std::string, std::string> content;
   ctlerr_t err;
+
+  DevInfoResp() : err(NOERR) {}
 };
 
 struct DevVendorAttrsResp {
   std::vector<std::map<std::string, std::string>> content;
   ctlerr_t err;
+
+  DevVendorAttrsResp() : err(NOERR) {}
 };
 
 struct CantIdDevResp {
   bool content;
   ctlerr_t err;
+
+  CantIdDevResp() : err(NOERR) {}
 };
 
 class Client {

--- a/libsmartctl.h
+++ b/libsmartctl.h
@@ -62,17 +62,6 @@ struct CantIdDevResp {
 class Client {
 public:
   /**
-   * @brief getClient provides the interface to retrieve an instance of the
-   * singleton class Client.  Currently only the default "normal" SMART command
-   * failure tolerance is available.  Options for failure tolerance will come at
-   * a future release.
-   *
-   * @return reference to the instance of Client.  Will throw a runtime error if
-   * initialization routines do not succeed.
-   */
-  static Client &getClient();
-
-  /**
    * @brief Checks if device name of the param type can be identified.
    * Gaurantees if true, the device is not identifiable, but if true, it still
    * necessarily mean device is identifiable.
@@ -114,16 +103,13 @@ public:
   DevVendorAttrsResp getDevVendorAttrs(std::string const &devname,
                                        std::string const &type = "");
 
-  Client(Client const &l) = delete;
-  void operator=(Client const &l) = delete;
-
-private:
-  // Client default constructor intializes the smart interface and default
-  // database.  User supplied drive databases are not supported at this.
+public:
   Client();
 
-  ctlerr_t initDevice(smart_device_auto_ptr &device, std::string const &devname,
-                      std::string const &type);
+private:
+  class Impl;
+
+  Impl &impl_;
 };
-}
+} // namespace libsmartctl
 #endif

--- a/smartctl_errs.h
+++ b/smartctl_errs.h
@@ -18,7 +18,14 @@ enum ctlerr_t {
 };
 
 namespace libsmartctl {
-std::string errstr(ctlerr_t err);
-}
+/**
+ * @brief Returns std::string version of ctlerr_t
+ *
+ * @param err ctlerr_t to stringify
+ *
+ * @return std::string represntation of err code
+ */
+const std::string errStr(ctlerr_t err);
+} // namespace libsmartctl
 
 #endif


### PR DESCRIPTION
- pimpl idiom for libsmartctl client implementation to make public header less convoluted with unnecessary implementation details.

- error string function for ctlerr_t