### PR TITLE
libsmartctl: remove intialization exception

### DIFF
--- a/smartctl_errs.h
+++ b/smartctl_errs.h
@@ -15,6 +15,7 @@ enum ctlerr_t {
   // invalid blk device specificied
   DEVICEOPENERR,
   UNSUPPORTEDDEVICETYPE,
+  CLIENTINITIALIZTIONFAILURE,
 };
 
 namespace libsmartctl {


### PR DESCRIPTION
- Client initialization no longer throws an exception when it fails.  The original implementation was a flawed design as an initialization failure is not an exceptional event.  Exposed methods now return a CLIENTINITIALIZTIONFAILURE error when called if initialization was not successful.